### PR TITLE
Add a Tracker class to support aggregate-worst case consumption delay…

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -40,6 +40,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   REALTIME_SEGMENT_NUM_PARTITIONS("realtimeSegmentNumPartitions", false),
   LLC_SIMULTANEOUS_SEGMENT_BUILDS("llcSimultaneousSegmentBuilds", true),
   RESIZE_TIME_MS("milliseconds", false),
+  MAX_PINOT_CONSUMPTION_DELAY_MS("milliseconds", false),
   // Upsert metrics
   UPSERT_PRIMARY_KEYS_COUNT("upsertPrimaryKeysCount", false),
   // Dedup metrics

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/MaximumPinotConsumptionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/MaximumPinotConsumptionDelayTracker.java
@@ -1,0 +1,306 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.core.data.manager.realtime;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.pinot.common.metrics.ServerGauge;
+import org.apache.pinot.common.metrics.ServerMetrics;
+
+
+/**
+ * A Class to track maximum realtime delay for a given table on a given server.
+ * Highlights:
+ * 1-An object of this class is hosted by each RealtimeTableDataManager.
+ * 2-The object tracks ingestion delays for all partitions hosted by the current server for the given Realtime table.
+ * 3-Partition delays are updated by all LLRealtimeSegmentDataManager objects hosted in the corresponding
+ *   RealtimeTableDataManager.
+ * 4-The class tracks the maximum of all ingestion delays observed for all partitions of the given table.
+ * 5-A Metric is derived from reading the maximum tracked by this class.
+ * 6-Delay reported for partitions that do not have events to consume is reported as zero.
+ * 7-We track the time at which each delay sample was collected so that delay can be increased when partition stops
+ *   consuming for any reason other than no events being available for consumption.
+ * 8-Segments that go from CONSUMING to DROPPED states stop being tracked so their delays do not cloud
+ *   delays of active partitions.
+ * 9-When a segment goes from CONSUMING to ONLINE, we start ticking time for the corresponding partition.
+ *   If no consumption is noticed after a timeout, then we read ideal state to confirm the server still hosts the
+ *   partition. If not, we stop tracking the respective partition.
+ * 10-A timer thread is started by this object to track timeouts of partitions and drive the reading of their ideal
+ *    state.
+ *
+ *  The following diagram illustrates the object interactions with main external APIs
+ *
+ *     (CONSUMING -> ONLINE state change)
+ *             |
+ *      markPartition(partitionId)      |<-recordPinotConsumptionDelay()-{LLRealtimeSegmentDataManager(Partition 0}}
+ *            |                         |
+ * ___________V_________________________V_
+ * |           (Table X)                |<-recordPinotConsumptionDelay()-{LLRealtimeSegmentDataManager(Partition 1}}
+ * | MaximumPinotConsumptionDelayTracker|           ...
+ * |____________________________________|<-recordPinotConsumptionDelay()-{LLRealtimeSegmentDataManager (Partition n}}
+ *              ^                      ^
+ *              |                       \
+ *   tickInactivePartitions()    stopTrackingPinotConsumptionDelay(partitionId)
+ *    _________|__________                \
+ *   | TimerTrackingTask |          (CONSUMING -> DROPPED state change)
+ *   |___________________|
+ *
+ */
+
+public class MaximumPinotConsumptionDelayTracker {
+  /*
+   * Class to handle timer thread that will track inactive partitions
+   */
+  private class TrackingTimerTask extends TimerTask {
+    private String _name;
+    private MaximumPinotConsumptionDelayTracker _tracker;
+
+    public TrackingTimerTask(String name, MaximumPinotConsumptionDelayTracker tracker) {
+      _name = name;
+      _tracker = tracker;
+    }
+
+    @Override
+    public void run() {
+      // tick inactive partitions every interval of time to keep tracked partitions up to date
+      _tracker.tickInactivePartitions();
+    }
+  }
+
+  /*
+   * Class to keep a Pinot Consumption Delay measure and the time when the sample was taken (i.e. sample time)
+   * We will use the sample time to increase consumption delay when a partition stops consuming: the time
+   * difference between the sample time and current time will be added to the metric when read.
+   */
+  private class DelayMeasure {
+    public DelayMeasure(long t, long d) {
+      _delayMilliseconds = d;
+      _sampleTime = t;
+    }
+    public long _delayMilliseconds;
+    public long _sampleTime;
+  }
+
+  // HashMap used to store delay measures for all partitions active for the current table.
+  private ConcurrentHashMap<Long, DelayMeasure> _partitionToDelaySampleMap = new ConcurrentHashMap<>();
+  // We mark partitions that go from CONSUMING to ONLINE in _partitionsMarkedForConfirmation: if they do not
+  // go back to CONSUMING in some timeout, we confirm they are still hosted in this server by reading
+  // ideal state. This is done with the goal of minimizing reading ideal state for efficiency reasons.
+  // We do tick up counts associated with inactive partitions so that we can verify they are still
+  // hosted by the current server after a preconfigured number of ticks.
+  private ConcurrentHashMap<Long, Integer> _partitionsMarkedForConfirmation = new ConcurrentHashMap<>();
+  // Check ideal state only after _MAX_NUMBER_OF_TIME_TICKS_BEFORE_VERIFICATION * _TIMER_THREAD_TICK_INTERVAL_MS
+  private static final int MAX_NUMBER_OF_TIME_TICKS_BEFORE_VERIFICATION = 5;
+  // Sleep interval for timer thread that triggers read of ideal state
+  private static final int TIMER_THREAD_TICK_INTERVAL_MS = 60000;
+  // Delay Timer thread for this time after starting timer
+  private static final int INITIAL_TIMER_THREAD_DELAY_MS = 1000;
+  // Mutable versions of the above constants so we can test with smaller delays
+  int _maxNumberOfTicksBeforeVerification;
+  int _timerThreadTickIntervalMs;
+  int _initialTimeThreadDelayMs;
+
+  // The following two fields are used to track the current maximum delay and the reporting partition.
+  // private long _maxPinotConsumptionDelay;
+  // private long _maxPartitionId;
+
+  // Timer task to check partitions that are inactive against ideal state.
+  private TrackingTimerTask _timerTask;
+  private Timer _timer;
+
+  private ServerMetrics _serverMetrics;
+  private String _tableNameWithType;
+
+  private boolean _enableAging;
+
+  RealtimeTableDataManager _realTimeTableDataManager;
+
+  /*
+   * Helper function to update the maximum when the current maximum is removed or updated.
+   * If no samples left we set maximum to minimum so new samples can be recorded.
+   */
+  private DelayMeasure getMaximumDelay() {
+    DelayMeasure newMax = null;
+    for (long pid : _partitionToDelaySampleMap.keySet()) {
+      DelayMeasure currentMeasure = _partitionToDelaySampleMap.get(pid);
+      if ((newMax == null) || (currentMeasure._delayMilliseconds > newMax._delayMilliseconds)) {
+        newMax = currentMeasure;
+      }
+    }
+    return newMax;
+  }
+
+  /*
+   * This function will read ideal state for the given partition and return true if ideal state reflects the
+   * partition must be hosted by the current server, false otherwise.
+   *
+   * @param partitionId Partition ID that we want to verify is still hosted by this server.
+   */
+  private boolean isPartitionHostedByThisServerPerIdealState(long partitionId) {
+    return _realTimeTableDataManager.isPartitionHostedInThisServer(partitionId);
+  }
+
+  /*
+   * Helper function to be called when we should stop tracking a given partition. Removes the partition from
+   * all our maps, it also updates the maximum if the tracked partition was the previous maximum.
+   *
+   * @param partitionId partition ID which we should stop tracking.
+   */
+  private void removePartitionId(long partitionId) {
+    _partitionToDelaySampleMap.remove(partitionId);
+    // If we are removing a partition we should stop reading its ideal state.
+    _partitionsMarkedForConfirmation.remove(partitionId);
+   }
+
+  // Custom Constructor
+  public MaximumPinotConsumptionDelayTracker(ServerMetrics sm, String tableNameWithType, RealtimeTableDataManager tdm,
+      int maxNumberOfTicksBeforeVerification, int initialTimeThreadDelayMs, int timerThreadTickIntervalMs)
+      throws RuntimeException {
+    _serverMetrics = sm;
+    _tableNameWithType = tableNameWithType;
+    _realTimeTableDataManager = tdm;
+    // TBD handle negative timer values
+    if ((maxNumberOfTicksBeforeVerification < 0) || (initialTimeThreadDelayMs < 0)
+        || (timerThreadTickIntervalMs <= 0)) {
+      throw new RuntimeException("Illegal timer arguments");
+    }
+    _enableAging = true;
+    _maxNumberOfTicksBeforeVerification = maxNumberOfTicksBeforeVerification;
+    _initialTimeThreadDelayMs = initialTimeThreadDelayMs;
+    _timerThreadTickIntervalMs = timerThreadTickIntervalMs;
+    _timerTask = new TrackingTimerTask("TimerTask" + tableNameWithType, this);
+    _timer = new Timer();
+    _timer.schedule(_timerTask, _initialTimeThreadDelayMs, _timerThreadTickIntervalMs);
+    // Install callback metric
+    _serverMetrics.addCallbackTableGaugeIfNeeded(_tableNameWithType, ServerGauge.MAX_PINOT_CONSUMPTION_DELAY_MS,
+        () -> (long) getMaxPinotConsumptionDelay());
+  }
+
+  // Constructor that uses default timeout
+  public MaximumPinotConsumptionDelayTracker(ServerMetrics sm, String tableNameWithType,
+      RealtimeTableDataManager tdm) {
+    this(sm, tableNameWithType, tdm, MAX_NUMBER_OF_TIME_TICKS_BEFORE_VERIFICATION,
+        INITIAL_TIMER_THREAD_DELAY_MS, TIMER_THREAD_TICK_INTERVAL_MS);
+  }
+
+  /**
+   * Use to set or rest the aging of reported values.
+   * @param enableAging true if we want maximum to be aged as per sample time or false if we do not want to age
+   *                   samples
+   */
+  @VisibleForTesting
+  void setEnableAging(boolean enableAging) {
+    _enableAging = enableAging;
+  }
+
+  /*
+   * Called by LLRealTimeSegmentDataManagers to post delay updates to this tracker class.
+   * If the new sample represents a new Maximum we update the current maximum.
+   * If the new sample was for the partition that was maximum, but delay is not maximum anymore, we must select
+   * a new maximum.
+   *
+   * @param delayInMilliseconds pinot consumption delay being recorded.
+   * @param currentTime sample time.
+   * @param partitionId partition ID for which this delay is being recorded.
+   */
+  public void recordPinotConsumptionDelay(long delayInMilliseconds, long currentTime, long partitionId) {
+    // Store new measure and wipe old one for this partition
+    _partitionToDelaySampleMap.put(partitionId, new DelayMeasure(currentTime, delayInMilliseconds));
+    // If we are consuming we do not need to track this partition for removal.
+    _partitionsMarkedForConfirmation.remove(partitionId);
+  }
+
+  /*
+   * Handle partition removal event. This must be invoked when we stop serving a given partition for
+   * this table in the current server.
+   * This function will be invoked when we receive CONSUMING -> DROPPED / OFFLINE state transitions.
+   *
+   * @param partitionId partition id that we should stop tracking.
+   */
+  public void stopTrackingPinotConsumptionDelayForPartition(long partitionId) {
+    removePartitionId(partitionId);
+  }
+
+  /*
+   * This method is used for ticking up the time a partition has been out of CONSUMING state.
+   * When that time exceeds some threshold, we read from ideal state to confirm we still host the partition, if
+   * not we remove the partition from being tracked locally.
+   * This call is to be invoked by a timer thread that will periodically wake up and invoke this function.
+   */
+  public void tickInactivePartitions() {
+    for (long partitionId : _partitionsMarkedForConfirmation.keySet()) {
+      int currentTicks = _partitionsMarkedForConfirmation.get(partitionId);
+      if (++currentTicks >= _maxNumberOfTicksBeforeVerification) {
+        if (!isPartitionHostedByThisServerPerIdealState(partitionId)) {
+          // If this partition is not hosted by this host as per ideal state we stop tracking
+          removePartitionId(partitionId);
+          return;
+        } else {
+          // Partition is hosted by us as per ideal state, hence do not track for removal
+          // Reset timeout and try later if it continues to not consume.
+          _partitionsMarkedForConfirmation.put(partitionId, 0);
+        }
+      } else {
+        // If not enough time in inactive state, we just add to the timeout count
+        _partitionsMarkedForConfirmation.put(partitionId, currentTicks);
+      }
+    }
+  }
+
+  /*
+   * This function is invoked when a partition goes from CONSUMING to ONLINE, so we can assert whether the
+   * partition is still hosted by this server after some interval of time.
+   *
+   * @param partitionId Partition id that we need confirmed via ideal state as still hosted by this server.
+   */
+  public void markPartitionForConfirmation(long partitionId) {
+    _partitionsMarkedForConfirmation.put(partitionId, 0);
+  }
+
+  /*
+   * This is the function to be invoked when reading the metric.
+   * It reports the maximum Pinot Consumption delay for all partitions of this table being served
+   * by current server; it adds the time elapsed since the sample was taken to the measure.
+   * If no measures have been taken, then the reported value is zero.
+   */
+  public long getMaxPinotConsumptionDelay() {
+    DelayMeasure currentMaxDelay = getMaximumDelay();
+    if (currentMaxDelay == null) {
+      return 0; // return 0 when not initialized
+    }
+    // Add age of measure to the reported value
+    long measureAgeInMs = _enableAging ? (System.currentTimeMillis() - currentMaxDelay._sampleTime) : 0;
+    // Correct to zero for any time shifts due to NTP or time reset.
+    measureAgeInMs = measureAgeInMs >= 0 ? measureAgeInMs : 0;
+    return currentMaxDelay._delayMilliseconds + measureAgeInMs;
+  }
+
+  /*
+   * We use this method to clean up when a table is being removed. No updates are expected at this time
+   * as all LLRealtimeSegmentManagers should be down now.
+   */
+  public void shutdown() {
+    // Now that segments can't report metric, destroy metric for this table
+    _timer.cancel();
+    _serverMetrics.removeTableGauge(_tableNameWithType, ServerGauge.MAX_PINOT_CONSUMPTION_DELAY_MS);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/MaximumPinotConsumptionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/MaximumPinotConsumptionDelayTrackerTest.java
@@ -1,0 +1,251 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.core.data.manager.realtime;
+
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class MaximumPinotConsumptionDelayTrackerTest {
+
+  private static final int NUMBER_OF_TIME_TICKS_BEFORE_VERIFICATION = 1;
+  private static final int TIMER_THREAD_TICK_INTERVAL_MS = 100;
+  private static final int INITIAL_TIMER_THREAD_DELAY_MS = 100;
+
+  private void sleepMs(long timeMs) {
+    while (true) {
+      try {
+        Thread.sleep(timeMs);
+      } catch (InterruptedException e) {
+        continue;
+      }
+      break;
+    }
+  }
+
+  private long getAgeOfSample(long sampleTime) {
+    long ageOfSample = System.currentTimeMillis() - sampleTime;
+    ageOfSample = ageOfSample > 0 ? ageOfSample : 0;
+    return ageOfSample;
+  }
+
+  private MaximumPinotConsumptionDelayTracker createTracker(boolean enableAging) {
+    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    RealtimeTableDataManager realtimeTableDataManager = new RealtimeTableDataManager(null);
+    MaximumPinotConsumptionDelayTracker maximumPinotConsumptionDelayTracker =
+        new MaximumPinotConsumptionDelayTracker(serverMetrics, "dummyTable_RT",
+            realtimeTableDataManager);
+    // With no samples, the time reported must be zero
+    Assert.assertEquals(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay(), 0);
+    maximumPinotConsumptionDelayTracker.setEnableAging(enableAging);
+    return maximumPinotConsumptionDelayTracker;
+  }
+
+  @Test
+  public void testTrackerConstructors() {
+    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    RealtimeTableDataManager realtimeTableDataManager = new RealtimeTableDataManager(null);
+    // Test regular constructor
+    MaximumPinotConsumptionDelayTracker maximumPinotConsumptionDelayTracker =
+        new MaximumPinotConsumptionDelayTracker(serverMetrics, "dummyTable_RT",
+            realtimeTableDataManager);
+    Assert.assertEquals(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay(), 0);
+    maximumPinotConsumptionDelayTracker.shutdown();
+    // Test constructor with timer arguments
+    maximumPinotConsumptionDelayTracker =
+        new MaximumPinotConsumptionDelayTracker(serverMetrics, "dummyTable_RT",
+            realtimeTableDataManager, NUMBER_OF_TIME_TICKS_BEFORE_VERIFICATION, INITIAL_TIMER_THREAD_DELAY_MS,
+            TIMER_THREAD_TICK_INTERVAL_MS);
+    Assert.assertEquals(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay(), 0);
+    maximumPinotConsumptionDelayTracker.shutdown();
+    // Test bad timer args to the constructor
+    try {
+      maximumPinotConsumptionDelayTracker =
+          new MaximumPinotConsumptionDelayTracker(serverMetrics, "dummyTable_RT",
+              realtimeTableDataManager, -1,
+              INITIAL_TIMER_THREAD_DELAY_MS, TIMER_THREAD_TICK_INTERVAL_MS);
+      Assert.assertTrue(false); // Constructor must assert
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof RuntimeException);
+    }
+    try {
+      maximumPinotConsumptionDelayTracker =
+          new MaximumPinotConsumptionDelayTracker(serverMetrics, "dummyTable_RT",
+              realtimeTableDataManager, NUMBER_OF_TIME_TICKS_BEFORE_VERIFICATION,
+              -1, TIMER_THREAD_TICK_INTERVAL_MS);
+      Assert.assertTrue(false); // Constructor must assert
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof RuntimeException);
+    }
+    try {
+      maximumPinotConsumptionDelayTracker =
+          new MaximumPinotConsumptionDelayTracker(serverMetrics, "dummyTable_RT",
+              realtimeTableDataManager, NUMBER_OF_TIME_TICKS_BEFORE_VERIFICATION,
+              INITIAL_TIMER_THREAD_DELAY_MS, 0);
+      Assert.assertTrue(false); // Constructor must assert
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof RuntimeException);
+    }
+  }
+
+  @Test
+  public void testRecordPinotConsumptionDelayWithNoAging() {
+    final long maxTestDelay = 100;
+    final long partition0 = 0;
+    final long partition1 = 1;
+
+    MaximumPinotConsumptionDelayTracker maximumPinotConsumptionDelayTracker = createTracker(false);
+
+    // Test we follow a single partition up and down
+    for (long i = 0; i <= maxTestDelay; i++) {
+      maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(i, 0,
+          partition0);
+      Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay() == i);
+    }
+
+    // Test tracking down a measure for a given partition
+    for (long i = maxTestDelay; i >= 0; i--) {
+      maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(i, 0,
+          partition0);
+      Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay() == i);
+    }
+
+    // Make the current partition maximum
+    maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(maxTestDelay, 0, partition0);
+
+    // Bring up partition1 delay up and verify values
+    for (long i = 0; i <= 2 * maxTestDelay; i++) {
+      maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(i, 0, partition1);
+      if (i >= maxTestDelay) {
+        Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay() == i);
+      } else {
+        // for values of i <= mextTestDelay, the max should be that of partition0
+        Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay() == maxTestDelay);
+      }
+    }
+
+    // Bring down values of partition1 and verify values
+    for (long i = 2 * maxTestDelay; i >= 0; i--) {
+      maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(i, 0, partition1);
+      if (i >= maxTestDelay) {
+        Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay() == i);
+      } else {
+        // for values of i <= mextTestDelay, the max should be that of partition0
+        Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay() == maxTestDelay);
+      }
+    }
+
+    maximumPinotConsumptionDelayTracker.shutdown();
+    Assert.assertTrue(true);
+  }
+
+  @Test(invocationCount = 10)
+  public void testRecordPinotConsumptionDelayWithAging() {
+    final long partition0 = 0;
+    final long partition0Delay0 = 1000;
+    final long partition0Delay1 = 10; // record lower delay to make sure max gets reduced
+    final long partition1 = 1;
+    final long partition1Delay0 = 11; // Record something slightly higher than previous max
+    final long partition1Delay1 = 8;  // Record something lower so that partition0 is the current max again
+    final long sleepMs = 500;
+
+    MaximumPinotConsumptionDelayTracker maximumPinotConsumptionDelayTracker = createTracker(true);
+
+    // With samples for a single partition, time reported should be at least sample plus aging
+    long partition0SampleTime = System.currentTimeMillis();
+    maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(partition0Delay0, partition0SampleTime,
+        partition0);
+    long agingOfSample = getAgeOfSample(partition0SampleTime);
+    Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay()
+        >= (partition0Delay0 + agingOfSample));
+
+    // Test we are aging the delay measures by sleeping some time and verifying that time was added to the measure
+    sleepMs(sleepMs);
+    agingOfSample = getAgeOfSample(partition0SampleTime);
+    Assert.assertTrue(agingOfSample >= sleepMs);
+    Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay()
+        >= (partition0Delay0 + agingOfSample));
+
+    // Add a new value below max and verify we are tracking and verify that the new maximum is being tracked.
+    partition0SampleTime = System.currentTimeMillis();
+    maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(partition0Delay1, partition0SampleTime,
+        partition0);
+    agingOfSample = getAgeOfSample(partition0SampleTime);
+    long maxDelay = maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay();
+    Assert.assertTrue(maxDelay >= (partition0Delay1 + agingOfSample));
+
+    // Now try setting a new maximum for another partition
+    long partition1SampleTime = System.currentTimeMillis();
+    maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(partition1Delay0, partition1SampleTime,
+        partition1);
+    agingOfSample = getAgeOfSample(partition1SampleTime);
+    maxDelay = maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay();
+    Assert.assertTrue(maxDelay >= (partition1Delay0 + agingOfSample));
+
+    // Now try to set partition 1 below partition 0 and confirm that partition 0 becomes the new max
+    partition1SampleTime = System.currentTimeMillis();
+    maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(partition1Delay1, partition1SampleTime,
+        partition1);
+    // Partition 0 must be the new max
+    agingOfSample = getAgeOfSample(partition0SampleTime);
+    maxDelay = maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay();
+    Assert.assertTrue(maxDelay >= (partition0Delay1 + agingOfSample));
+
+    // Test setting partition 1 to zero, maximum should still be partition 0 last sample
+    partition1SampleTime = System.currentTimeMillis();
+    maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(0, partition1SampleTime,
+        partition1);
+    agingOfSample = getAgeOfSample(partition0SampleTime);
+    maxDelay = maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay();
+    Assert.assertTrue(maxDelay >= (partition0Delay1 + agingOfSample));
+
+    maximumPinotConsumptionDelayTracker.shutdown();
+  }
+
+  @Test
+  public void testStopTrackingPinotConsumptionDelay() {
+    final long maxTestDelay = 100;
+    final long partition0 = 0;
+
+    MaximumPinotConsumptionDelayTracker maximumPinotConsumptionDelayTracker = createTracker(false);
+    // Record a number of partitions with delay equal to partition id
+    for (long partitionId = 0; partitionId <= maxTestDelay; partitionId++) {
+      maximumPinotConsumptionDelayTracker.recordPinotConsumptionDelay(partitionId, 0, partitionId);
+      Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay() == partitionId);
+    }
+    // Verify that as we remove partitions the next available maximum takes over
+    for (long partitionId = maxTestDelay; partitionId >= 0; partitionId--) {
+      Assert.assertTrue(maximumPinotConsumptionDelayTracker.getMaxPinotConsumptionDelay() == partitionId);
+      maximumPinotConsumptionDelayTracker.stopTrackingPinotConsumptionDelayForPartition(partitionId);
+    }
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testTickInactivePartitions() {
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testMarkPartitionForConfirmation() {
+    Assert.assertTrue(true);
+  }
+}


### PR DESCRIPTION
… in Pinot

Early draft for review, no significant unitest or end to end testing done yet.
Missing: code to read ideal state, unitets.

`feature`

`testing`: made sure that we do not break any of the existing server tests:

[INFO] Results:
[INFO] 
[INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 

`release-notes` New metric for consumption delay.